### PR TITLE
fix: payment verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - **Tags:** squad, woocommerce, payment, payment gateway, bank account, credit card, debit card, nigeria, international, mastercard, visa
 - **Requires at least:** 4.4
 - **Tested up to:** 6.0.1
-- **Stable tag:** 1.0.7
+- **Stable tag:** 1.0.8
 - **License:** MIT - see below
 - **License URI:** https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/includes/class-wc-payment-gateway-squad.php
+++ b/includes/class-wc-payment-gateway-squad.php
@@ -540,7 +540,7 @@ class WC_Gateway_Squad extends WC_Payment_Gateway
 				$squad_response = json_decode(wp_remote_retrieve_body($request));
 
 				$transStatus = $squad_response->data->transaction_status;
-				$success = $transStatus == "Success" ? true : false;
+				$success = strtolower($transStatus) == "success" ? true : false;
 
 				if ($success) {
 
@@ -880,7 +880,6 @@ class WC_Gateway_Squad extends WC_Payment_Gateway
 	{
 
 
-		$this->logToFile('dsdsdsd');
 		if (!($this->public_key && $this->secret_key)) {
 			return false;
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@
 Contributors: Squad Developers
 Tags: squad, woocommerce, payment, payment gateway, bank account, credit card, debit card, nigeria, international, mastercard, visa
 Tested up to: 6.0.2
-Stable tag: 1.0.7
+Stable tag: 1.0.8
 Requires PHP: 5.6
 License: MIT - see below
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/squad-payment-gateway-woocommerce.php
+++ b/squad-payment-gateway-woocommerce.php
@@ -6,7 +6,7 @@
  * Author: Squad Developers
  * Author URI: http://squadco.com/
  * Description: Provides Seamless Payments with Multiple payment options.
- * Version: 1.0.7
+ * Version: 1.0.8
  * Tested up to: 6.0.2
  * License: GPL2
  * License URL: http://www.gnu.org/licenses/gpl-2.0.txt


### PR DESCRIPTION
On successful payment,  `transaction_status` is cast to lowercase before comparing if it's `success`.